### PR TITLE
Improve LDC build switches

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,11 +27,11 @@ endif
 #lcd2
 ifeq ($(DC),ldc2)
 	ifeq ($(BUILD),popcount)
-		DFLAGS = -O5 -release -boundscheck=off -w -dw -d-version=withPopCount -mattr=+sse4.2,popcnt
+		DFLAGS = -O3 -release -boundscheck=off -w -dw -singleobj -d-version=withPopCount -mcpu=haswell
 	else ifeq ($(BUILD),fast)
-		DFLAGS = -O5 -release -boundscheck=off -w -dw
+		DFLAGS = -O3 -release -boundscheck=off -w -dw -singleobj -mcpu=haswell
 	else
-		DFLAGS = -O0 -g -gc
+		DFLAGS = -O0 -g -gc -singleobj
 	endif
 
 	PGO_GEN = -fprofile-instr-generate


### PR DESCRIPTION
-singleobj enables the equivalent for link-time optimisations by
allowing the compiler to emit only one object file (like DMD does
by default). -O4/-O5 are equivalent to -O3, so use the latter.

I also added -mcpu=haswell similar to the GDC build flags, but the
impact of that might be minor.

On my machine (i7-4980HQ, 2.8 GHz), this reduces the time
"amoeba bench -f bk.epd -d 14" takes from 19.1 s for a plain build
before this to 15.1 s, and 12.2 s for a popcount build.
